### PR TITLE
fix broken decorator parsing

### DIFF
--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -223,6 +223,7 @@ impl Module {
         self.sql.len() == 1
     }
 
+    #[allow(dead_code)]
     pub fn from_str<'a>(path: PathBuf, data: &'a str) -> CResult<'a, Self> {
         let (_, ast) = Ast::parse(path, data).map_err(|err| match err {
             nom::Err::Incomplete(_) => ParseError::const_error(data, "incomplete"),

--- a/src/codegen/module.rs
+++ b/src/codegen/module.rs
@@ -223,6 +223,15 @@ impl Module {
         self.sql.len() == 1
     }
 
+    pub fn from_str<'a>(path: PathBuf, data: &'a str) -> CResult<'a, Self> {
+        let (_, ast) = Ast::parse(path, data).map_err(|err| match err {
+            nom::Err::Incomplete(_) => ParseError::const_error(data, "incomplete"),
+            nom::Err::Error(err) => err,
+            nom::Err::Failure(err) => err,
+        })?;
+        Ok(Self::new::<&Path, Module>(ast, &BTreeMap::new())?)
+    }
+
     pub fn new<'a, P: Borrow<Path> + Ord, M: Borrow<Module>>(
         ast: Ast<'a>,
         modules: &BTreeMap<P, M>,
@@ -435,7 +444,7 @@ OR 0 = @id"#;
         assert_eq!(
             format!("{:?}", &err)
             ,
-            "Failure(Multiple([ErrorKind(\"@id \\nAND @email = \\\'testing 123 @haha\\\' \\nOR 0 = @id\", UndefinedParameterError(\"id\")), ErrorKind(\"@id\", UndefinedParameterError(\"id\"))]))"
+            "Multiple([ErrorKind(\"@id \\nAND @email = \\\'testing 123 @haha\\\' \\nOR 0 = @id\", UndefinedParameterError(\"id\")), ErrorKind(\"@id\", UndefinedParameterError(\"id\"))])"
         );
 
         let test_str = r#"

--- a/src/command/peek.rs
+++ b/src/command/peek.rs
@@ -38,17 +38,7 @@ impl Command for Peek {
                 let (bindings, auth_bindings) =
                     super::read_input(self.json.as_str(), self.auth.as_ref().map(String::as_str))?;
 
-                let pool = sqlx::postgres::PgPoolOptions::new()
-                    .max_connections(1)
-                    .connect(
-                        config
-                            .database
-                            .url
-                            .and_then(|v| Some(v.value()?.into_owned()))
-                            .ok_or_else(|| anyhow!("must have database url set in config"))?
-                            .as_str(),
-                    )
-                    .await?;
+                let pool = crate::server::init::connect_to_db(&config, Some(1)).await?;
 
                 let module = importer.get_module_from_location(
                     Path::new(self.module.as_str()).canonicalize()?.as_path(),

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -37,18 +37,7 @@ impl Command for Run {
 
                 let (bindings, auth_bindings) =
                     super::read_input(self.json.as_str(), self.auth.as_ref().map(String::as_str))?;
-
-                let pool = sqlx::postgres::PgPoolOptions::new()
-                    .max_connections(1)
-                    .connect(
-                        config
-                            .database
-                            .url
-                            .and_then(|v| Some(v.value()?.into_owned()))
-                            .ok_or_else(|| anyhow!("must have database url set in config"))?
-                            .as_str(),
-                    )
-                    .await?;
+                let pool = crate::server::init::connect_to_db(&config, Some(1)).await?;
 
                 let module = importer.get_module_from_location(
                     Path::new(self.module.as_str()).canonicalize()?.as_path(),

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -64,19 +64,8 @@ pub async fn run_server(cmd: Server) -> anyhow::Result<()> {
     let evaluator = create_evaluator(cmd.directory.as_str(), cmd.extension.as_str(), cmd.watch)?;
 
     let config = Config::read_config()?;
+    let pool = crate::server::init::connect_to_db(&config, None).await?;
     let config = Arc::new(config);
-
-    let pool = sqlx::postgres::PgPoolOptions::new()
-        .connect(
-            config
-                .database
-                .url
-                .as_ref()
-                .and_then(|v| v.value().map(|v| v.into_owned()))
-                .ok_or_else(|| anyhow!("must have database url set in config"))?
-                .as_str(),
-        )
-        .await?;
 
     for endpoint in evaluator.importer.get_all_endpoints()? {
         info!("using endpoint {}", endpoint)

--- a/src/server/init.rs
+++ b/src/server/init.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use sqlx::{Pool, Postgres};
+
+use crate::config::Config;
+
+/// connects the
+pub async fn connect_to_db(
+    config: &Config,
+    max_connections: Option<u32>,
+) -> anyhow::Result<Pool<Postgres>> {
+    info!("connecting to the database");
+    let pool = sqlx::postgres::PgPoolOptions::new()
+        .connect_timeout(Duration::from_secs_f32(10f32))
+        .max_connections(max_connections.unwrap_or(10u32))
+        .connect(
+            config
+                .database
+                .url
+                .as_ref()
+                .and_then(|v| v.value().map(|v| v.into_owned()))
+                .ok_or_else(|| anyhow!("must have database url set in config"))?
+                .as_str(),
+        )
+        .await?;
+    Ok(pool)
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,1 +1,2 @@
 pub mod routes;
+pub mod init;


### PR DESCRIPTION
`'@param verify\n` would not parse but `@param verify \n` would. This is clearly a bug.