### PR TITLE
add cors (resolves #9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ regex = "1.4"
 clap = "3.0.0-beta.2"
 anyhow = "1.0"
 tokio = { version = "1.5.0", features=[ "rt"] }
-sqlx = { version = "0.5", features = [ "runtime-actix-rustls", "postgres", "json", "chrono", "uuid", "decimal" ] }
+sqlx = { version = "0.4", features = [ "runtime-actix-rustls", "postgres", "json", "chrono", "uuid", "decimal" ] }
 chrono = { version = "0.4", features = ["serde"] }
 decimal = "2.1"
 uuid = { version = "0.8", features = ["v5", "v4", "serde"] }
@@ -27,8 +27,9 @@ futures = "0.3"
 glob = "0.3"
 
 
-actix-web = "4.0.0-beta.6"
-actix-rt = "2.2"
+actix-web = "3.0"
+actix-rt = "1.1"
+actix-cors = "0.5"
 
 env_logger = "0.8"
 jsonwebtoken = "7"

--- a/justsql.config.yml
+++ b/justsql.config.yml
@@ -19,3 +19,9 @@ auth:
 cookie:
   secure: true
   http_only: true
+
+cors:
+  allowed_origins:
+    # useful for dev development
+    - from_env: $CORS_ORIGIN
+      default: "http://localhost:2332"

--- a/justsql.config.yml
+++ b/justsql.config.yml
@@ -24,4 +24,4 @@ cors:
   allowed_origins:
     # useful for dev development
     - from_env: $CORS_ORIGIN
-      default: "http://localhost:2332"
+      default: "http://localhost:3000"

--- a/src/command/mod.rs
+++ b/src/command/mod.rs
@@ -33,6 +33,11 @@ pub fn read_json_or_json_file<T: DeserializeOwned>(data: &str) -> anyhow::Result
 #[derive(Clap)]
 #[clap(version = "0.2.0", author = "Shalom Yiblet <shalom.yiblet@gmail.com>")]
 pub struct Opts {
+    /// Set the file path where justsql will read the configs from. If this is left unset,
+    /// justsql will recursively look for a `justsql.config.yaml` in current and parent
+    /// directories.
+    #[clap(short, long)]
+    config: Option<std::path::PathBuf>,
     #[clap(subcommand)]
     subcmd: SubCommand,
 }

--- a/src/command/peek.rs
+++ b/src/command/peek.rs
@@ -24,7 +24,7 @@ pub struct Peek {
 }
 
 impl Command for Peek {
-    fn run_command(&self, _opt: &Opts) -> anyhow::Result<()> {
+    fn run_command(&self, opt: &Opts) -> anyhow::Result<()> {
         let importer = UpfrontImporter::from_paths_or_print_error(&[self.module.as_ref()])
             .ok_or_else(|| anyhow!("importing sql failed"))?;
 
@@ -32,7 +32,7 @@ impl Command for Peek {
             .enable_all()
             .build()?
             .block_on(async {
-                let config = crate::config::Config::read_config()
+                let config = crate::config::Config::read_config(opt.config.as_ref())
                     .context("config is needed to find postgres_url")?;
 
                 let (bindings, auth_bindings) =

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -24,7 +24,7 @@ pub struct Run {
 }
 
 impl Command for Run {
-    fn run_command(&self, _opt: &Opts) -> anyhow::Result<()> {
+    fn run_command(&self, opt: &Opts) -> anyhow::Result<()> {
         let importer = UpfrontImporter::from_paths_or_print_error(&[self.module.as_ref()])
             .ok_or_else(|| anyhow!("importing sql failed"))?;
 
@@ -32,7 +32,7 @@ impl Command for Run {
             .enable_all()
             .build()?
             .block_on(async {
-                let config = crate::config::Config::read_config()
+                let config = crate::config::Config::read_config(opt.config.as_ref())
                     .context("config is needed to find postgres_url")?;
 
                 let (bindings, auth_bindings) =

--- a/src/command/server.rs
+++ b/src/command/server.rs
@@ -34,7 +34,7 @@ pub struct Server {
 impl Command for Server {
     fn run_command(&self, opt: &Opts) -> anyhow::Result<()> {
         let clone = self.clone();
-        actix_rt::System::new().block_on(run_server(opt.config.as_ref(), clone))?;
+        actix_rt::System::new("server").block_on(run_server(opt.config.clone(), clone))?;
         Ok(())
     }
 }
@@ -59,7 +59,7 @@ fn create_evaluator(directory: &str, extension: &str, watch: bool) -> anyhow::Re
     }
 }
 
-pub async fn run_server(config_path: Option<&PathBuf>, cmd: Server) -> anyhow::Result<()> {
+pub async fn run_server(config_path: Option<PathBuf>, cmd: Server) -> anyhow::Result<()> {
     // import all files
     let evaluator = create_evaluator(cmd.directory.as_str(), cmd.extension.as_str(), cmd.watch)?;
 
@@ -77,6 +77,7 @@ pub async fn run_server(config_path: Option<&PathBuf>, cmd: Server) -> anyhow::R
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(middleware::Compress::default())
+            .wrap(config.cors.cors())
             .data(config.clone())
             .data(pool.clone())
             .data(evaluator.clone())

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -32,7 +32,10 @@ pub struct Cors {
 
 impl Cors {
     pub fn cors(&self) -> actix_cors::Cors {
-        let mut cors = actix_cors::Cors::default();
+        let mut cors = actix_cors::Cors::default()
+            .allowed_methods(vec!["GET", "POST", "OPTIONS"])
+            .max_age(Some(600));
+
         for origin in self
             .allowed_origins
             .iter()

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -14,12 +14,35 @@ pub struct Config {
     pub auth: Option<Secret>,
     #[serde(default)]
     pub cookie: Cookie,
+    #[serde(default)]
+    pub cors: Cors,
 }
 
 #[derive(Serialize, Deserialize, Default)]
 pub struct Database {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<EnvValue<String>>,
+}
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct Cors {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_origins: Option<Vec<EnvValue<String>>>,
+}
+
+impl Cors {
+    pub fn cors(&self) -> actix_cors::Cors {
+        let mut cors = actix_cors::Cors::default();
+        for origin in self
+            .allowed_origins
+            .iter()
+            .flat_map(|vec| vec.iter())
+            .filter_map(|val| val.value())
+        {
+            cors = cors.allowed_origin(origin.as_ref().as_str());
+        }
+        cors
+    }
 }
 
 #[derive(Serialize, Deserialize)]

--- a/src/config/config.rs
+++ b/src/config/config.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, env, fs::File};
+use std::{borrow::Cow, env, fs::File, path::Path};
 
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
@@ -92,40 +92,55 @@ impl Default for Cookie {
 
 impl Config {
     /// read config from env
-    pub fn read_config() -> anyhow::Result<Config> {
-        let run = || {
-            let mut cur = env::current_dir()?;
-            loop {
-                // check first if the .yaml file exists
-                cur.push("justsql.config.yaml");
-                let is_file = cur.as_path().metadata().map_or(false, |m| m.is_file());
-                if is_file {
-                    break;
-                }
-                cur.pop();
+    pub fn read_config<P: AsRef<Path>>(file_path_opt: Option<P>) -> anyhow::Result<Config> {
+        let config_res = match file_path_opt {
+            Some(path) => Self::read_config_from_file_path(path),
+            None => Self::read_config_from_directory_parents(),
+        };
+        config_res.context("failed to read config file")
+    }
 
-                // else check if the .yml file exists
-                cur.push("justsql.config.yml");
-                let is_file = cur.as_path().metadata().map_or(false, |m| m.is_file());
-                if is_file {
-                    break;
-                }
-                cur.pop();
+    pub fn read_config_from_file_path<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        let file = File::open(path)?;
+        let mut config: Config = serde_yaml::from_reader(file)?;
+        if let Some(secret) = config.auth.as_mut() {
+            secret.post_process()?
+        }
+        Ok(config)
+    }
 
-                if !cur.pop() {
-                    return Err(anyhow!(
+    fn read_config_from_directory_parents() -> anyhow::Result<Self> {
+        let mut cur = env::current_dir()?;
+        loop {
+            // check first if the .yaml file exists
+            cur.push("justsql.config.yaml");
+            let is_file = cur.as_path().metadata().map_or(false, |m| m.is_file());
+            if is_file {
+                break;
+            }
+            cur.pop();
+
+            // else check if the .yml file exists
+            cur.push("justsql.config.yml");
+            let is_file = cur.as_path().metadata().map_or(false, |m| m.is_file());
+            if is_file {
+                break;
+            }
+            cur.pop();
+
+            if !cur.pop() {
+                return Err(anyhow!(
                     "could not find or open a justsql.config.yaml file in current or parent directories"
                 ));
-                }
             }
+        }
 
-            let file = File::open(&cur)?;
-            let mut config: Config = serde_yaml::from_reader(file)?;
-            if let Some(secret) = config.auth.as_mut() {
-                secret.post_process()?
-            }
-            Ok(config)
-        };
-        run().context("failed to read config file")
+        let file = File::open(&cur)?;
+        let mut config: Config = serde_yaml::from_reader(file)?;
+        if let Some(secret) = config.auth.as_mut() {
+            secret.post_process()?
+        }
+        Ok(config)
     }
 }

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -1,4 +1,4 @@
-use actix_web::{web, HttpRequest, HttpResponse, Responder};
+use actix_web::{web, HttpMessage, HttpRequest, HttpResponse, Responder};
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use sqlx::{postgres::PgArguments, PgPool, Postgres};


### PR DESCRIPTION
resolves #9

This allows users to set up CORS allow_origin rules, in the config.

this is what it'd look like in the yaml configs:
```yaml
cors:
  allowed_origins:
    - http://localhost:3000
    - http://localhost:3001
    - https://localhost:3000
    - https://localhost:3001
```
