### PR TITLE
remove common error printing panics

### DIFF
--- a/src/codegen/ast/sql.rs
+++ b/src/codegen/ast/sql.rs
@@ -199,7 +199,7 @@ fn parse_sql_statement<'a>(input: &'a str) -> PResult<'a, StatementSpan<'a>> {
             .map_err(|err: nom::Err<ParseError>| {
                 err.map(|err| match err {
                     ParseError::NomError(input, nom::error::ErrorKind::Many1) => {
-                        ParseError::const_error(input, "statement(s) are empty")
+                        ParseError::const_error(input, "must have at least one sql statement")
                     }
                     _ => err,
                 })

--- a/src/util/error_printing.rs
+++ b/src/util/error_printing.rs
@@ -111,6 +111,13 @@ pub fn print_error<W: Write>(
         "finding error in file {} at position {}",
         file_name, position
     );
+    if file.len() == 0 {
+        return print_unpositioned_error(
+            writer,
+            format!("empty file: {}", explanation).as_str(),
+            file_name,
+        );
+    }
 
     // we shadow position here since find_row_col will sometimes
     // go back a line if the current position is at the line beginning.
@@ -231,9 +238,7 @@ where id = user.id
 "#,
         );
 
-        assert_row_position(
-            r#"--"#,
-        );
+        assert_row_position(r#"--"#);
 
         assert_row_position(
             r#"select * from users


### PR DESCRIPTION
print errors could be caused by two edge cases: 

1. A parsing error pointing to the last character in the file 
2. A parsing error when the file is completely empty

This PR fixes both of these edge cases and ensures justsql will 
return something sensible when either issue arises.
